### PR TITLE
15 integrate api image endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -16,4 +16,4 @@ app.register_blueprint(food_blueprint, url_prefix='/api/foods')
 app.register_blueprint(image_blueprint, url_prefix='/api/images')
 
 if __name__ == '__main__':
-    app.run()
+    app.run(host='0.0.0.0', port=8080, debug=True)

--- a/client/components/Camera.tsx
+++ b/client/components/Camera.tsx
@@ -1,9 +1,17 @@
 import { CameraView, CameraType, useCameraPermissions } from "expo-camera";
 import { useState, useRef } from "react";
-import { Button, Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import {
+  Button,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { CameraType as CameraTypeEnum } from "../constants/CameraEnum";
+import PhotoPreview from "./PhotoPreview";
 
-export default function App() {
+export default function Camera() {
   const [facing, setFacing] = useState<CameraType>(CameraTypeEnum.BACK);
   const [permission, requestPermission] = useCameraPermissions();
   const [photo, setPhoto] = useState<string | null>(null);
@@ -43,12 +51,7 @@ export default function App() {
   return (
     <View className="flex-1">
       {photo ? (
-        <View className="flex-1 justify-center items-center">
-          <Image source={{ uri: photo }} className="w-4/5 h-3/5 rounded-lg"/>
-          <TouchableOpacity className="bg-blue-500 px-4 py-3 mt-4 rounded-lg" onPress={() => setPhoto(null)}>
-            <Text className="text-white text-lg font-semibold text-center">Retake</Text>
-          </TouchableOpacity>
-        </View>
+        <PhotoPreview photo={photo} setPhoto={setPhoto} />
       ) : (
         <CameraView style={styles.camera} facing={facing} ref={cameraRef}>
           <View className="absolute bottom-16 flex-row justify-between items-center w-full px-12">
@@ -70,4 +73,3 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 });
-

--- a/client/components/PhotoPreview.tsx
+++ b/client/components/PhotoPreview.tsx
@@ -6,8 +6,7 @@ interface PhotoPreviewProps {
   setPhoto: (photo: string | null) => void;
 }
 
-export default function PhotoPreview({ photo, setPhoto }: PhotoPreviewProps) {
-  const API_BASE_URL = "http://192.168.1.168:8080"; 
+export default function PhotoPreview({ photo, setPhoto }: PhotoPreviewProps) { 
   async function submitPicture() {
     const formData = new FormData();
 
@@ -19,7 +18,7 @@ export default function PhotoPreview({ photo, setPhoto }: PhotoPreviewProps) {
 
     try {
       const { data } = await axios.post(
-        `${API_BASE_URL}/api/images`,
+        `${process.env.EXPO_PUBLIC_API_URL}/api/images/`,
         formData,
         {
           headers: { "Content-Type": "multipart/form-data" },

--- a/client/components/PhotoPreview.tsx
+++ b/client/components/PhotoPreview.tsx
@@ -1,26 +1,65 @@
 import { Image, Text, TouchableOpacity, View } from "react-native";
-
+import ToastManager, { Toast } from "toastify-react-native";
+import axios from "axios";
 interface PhotoPreviewProps {
   photo: string;
   setPhoto: (photo: string | null) => void;
 }
 
-export default function PhotoPreview({photo, setPhoto}: PhotoPreviewProps) {
-    function sendPicture() {
-      console.log("HELLO");
+export default function PhotoPreview({ photo, setPhoto }: PhotoPreviewProps) {
+  const API_BASE_URL = "http://192.168.1.168:8080"; 
+  async function submitPicture() {
+    const formData = new FormData();
+
+    formData.append("image", {
+      uri: photo,
+      name: "photo.jpg",
+      type: "image/jpeg",
+    } as any);
+
+    try {
+      const { data } = await axios.post(
+        `${API_BASE_URL}/api/images`,
+        formData,
+        {
+          headers: { "Content-Type": "multipart/form-data" },
+        }
+      );
+      Toast.success(data.message || "Photo was sent!");
+
+    } catch (error: any) {
+      console.error(error);
+      if (error.response) {
+        Toast.error(error.response.data.error || "Failed to send photo.");
+      } else {
+        Toast.error("Network error! Please try again.");
+      }
     }
 
-    return (
-      <View className="flex-1 justify-center items-center">
-        <Image source={{ uri: photo }} className="w-4/5 h-3/5 rounded-lg"/>
-        <View className="flex flex-row gap-3 w-4/5 justify-evenly">
-          <TouchableOpacity className="bg-blue-500 px-4 py-3 mt-4 rounded-lg w-1/3" onPress={() => sendPicture()}>
-            <Text className="text-white text-lg font-semibold text-center">Submit</Text>
-          </TouchableOpacity>
-          <TouchableOpacity className="bg-red-500 px-4 py-3 mt-4 rounded-lg w-1/3" onPress={() => setPhoto(null)}>
-            <Text className="text-white text-lg font-semibold text-center">Retake</Text>
-          </TouchableOpacity>
-        </View>
+  }
+
+  return (
+    <View className="flex-1 justify-center items-center">
+      <ToastManager/>
+      <Image source={{ uri: photo }} className="w-4/5 h-3/5 rounded-lg" />
+      <View className="flex flex-row gap-3 w-4/5 justify-evenly">
+        <TouchableOpacity
+          className="bg-blue-500 px-4 py-3 mt-4 rounded-lg w-1/3"
+          onPress={() => submitPicture()}
+        >
+          <Text className="text-white text-lg font-semibold text-center">
+            Submit
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          className="bg-red-500 px-4 py-3 mt-4 rounded-lg w-1/3"
+          onPress={() => setPhoto(null)}
+        >
+          <Text className="text-white text-lg font-semibold text-center">
+            Retake
+          </Text>
+        </TouchableOpacity>
       </View>
-    )
+    </View>
+  );
 }

--- a/client/components/PhotoPreview.tsx
+++ b/client/components/PhotoPreview.tsx
@@ -1,0 +1,26 @@
+import { Image, Text, TouchableOpacity, View } from "react-native";
+
+interface PhotoPreviewProps {
+  photo: string;
+  setPhoto: (photo: string | null) => void;
+}
+
+export default function PhotoPreview({photo, setPhoto}: PhotoPreviewProps) {
+    function sendPicture() {
+      console.log("HELLO");
+    }
+
+    return (
+      <View className="flex-1 justify-center items-center">
+        <Image source={{ uri: photo }} className="w-4/5 h-3/5 rounded-lg"/>
+        <View className="flex flex-row gap-3 w-4/5 justify-evenly">
+          <TouchableOpacity className="bg-blue-500 px-4 py-3 mt-4 rounded-lg w-1/3" onPress={() => sendPicture()}>
+            <Text className="text-white text-lg font-semibold text-center">Submit</Text>
+          </TouchableOpacity>
+          <TouchableOpacity className="bg-red-500 px-4 py-3 mt-4 rounded-lg w-1/3" onPress={() => setPhoto(null)}>
+            <Text className="text-white text-lg font-semibold text-center">Retake</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    )
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.0.14",
         "@rneui/themed": "^4.0.0-rc.8",
         "@supabase/supabase-js": "^2.47.14",
+        "axios": "^1.7.9",
         "dotenv": "^16.4.7",
         "expo": "~52.0.26",
         "expo-blur": "~14.0.2",
@@ -40,7 +41,8 @@
         "react-native-screens": "~4.4.0",
         "react-native-web": "~0.19.13",
         "react-native-webview": "13.12.5",
-        "tailwindcss": "^3.4.17"
+        "tailwindcss": "^3.4.17",
+        "toastify-react-native": "^5.0.4"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -5433,6 +5435,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -8179,6 +8204,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -12804,6 +12848,11 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -13130,6 +13179,15 @@
         }
       }
     },
+    "node_modules/react-native-animatable": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.3.3.tgz",
+      "integrity": "sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==",
+      "peer": true,
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "node_modules/react-native-config": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.5.3.tgz",
@@ -13229,6 +13287,15 @@
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "peer": true,
+      "peerDependencies": {
+        "react-native": ">=0.42.0"
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.6.tgz",
@@ -13237,6 +13304,20 @@
       "peerDependencies": {
         "react": ">=18.2.0",
         "react-native": ">=0.73.0"
+      }
+    },
+    "node_modules/react-native-modal": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-13.0.1.tgz",
+      "integrity": "sha512-UB+mjmUtf+miaG/sDhOikRfBOv0gJdBU2ZE1HtFWp6UixW9jCk/bhGdHUgmZljbPpp0RaO/6YiMmQSSK3kkMaw==",
+      "peer": true,
+      "dependencies": {
+        "prop-types": "^15.6.2",
+        "react-native-animatable": "1.3.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.65.0"
       }
     },
     "node_modules/react-native-ratings": {
@@ -13275,6 +13356,18 @@
         "@babel/core": "^7.0.0-0",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-responsive-fontsize": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-responsive-fontsize/-/react-native-responsive-fontsize-0.5.1.tgz",
+      "integrity": "sha512-G77iPzrf3BHxMxVm6G3Mw3vPImIdq+jLLXhYoOjWei6i9J3/jzUNUhNdRWvp49Csb5prhbVBLPM+pYZz+b3ESQ==",
+      "peer": true,
+      "dependencies": {
+        "react-native-iphone-x-helper": "^1.3.1"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.42.0"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -13316,7 +13409,6 @@
       "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.2.0.tgz",
       "integrity": "sha512-n5HGcxUuVaTf9QJPs/W22xQpC2Z9u0nb0KgLPnVltP8vdUvOp6+R26gF55kilP/fV4eL4vsAHUqUjewppJMBOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prop-types": "^15.7.2",
         "yargs": "^16.1.1"
@@ -13333,7 +13425,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -13344,15 +13435,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-native-vector-icons/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -13367,7 +13456,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -13380,7 +13468,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -13399,7 +13486,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -15360,6 +15446,20 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toastify-react-native": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/toastify-react-native/-/toastify-react-native-5.0.4.tgz",
+      "integrity": "sha512-7YgzFtx3GBqIhK/3pBG0feaNc22XVCnV2YnoQNAWUCmt9PvQAPXs4TU0c3jsoHxjxyWPPjUC0ld/i0MzJ6uzzw==",
+      "dependencies": {
+        "react-native-vector-icons": "^10.2.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-modal": "*",
+        "react-native-responsive-fontsize": "*"
       }
     },
     "node_modules/toidentifier": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@react-navigation/native": "^7.0.14",
     "@rneui/themed": "^4.0.0-rc.8",
     "@supabase/supabase-js": "^2.47.14",
+    "axios": "^1.7.9",
     "dotenv": "^16.4.7",
     "expo": "~52.0.26",
     "expo-blur": "~14.0.2",
@@ -47,7 +48,8 @@
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "toastify-react-native": "^5.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Description 
- Added API connection from FE -> BE
- Added [Toast](https://www.npmjs.com/package/toastify-react-native) component for success/failure
- Installed [Axios](https://axios-http.com/docs/api_intro) for easier API requests.

## Screenshot

### Frontend:
<img src="https://github.com/user-attachments/assets/95b0782f-6d2e-4736-8025-edbb09ebcbd4" width = "400"/>

### Backend:
<img src="https://github.com/user-attachments/assets/d375b815-070c-4a4f-8306-1eb984061950" width = "600"/>

## Technical Notes
- Added a client `.env` file and inserted variable: `EXPO_PUBLIC_API_URL`. 
- Since the variable is subjective to your machine use the following format to configure:
```
EXPO_PUBLIC_API_URL=http://{IP_ADDRESS}:8080

// example: EXPO_PUBLIC_API_URL=http://192.142.1.128:8080
```
Replace the `IP_ADDRESS` with your own... You can find it running the command below:
```
ipconfig getifaddr en0
```
